### PR TITLE
Update sorting algorithm

### DIFF
--- a/docs/app/priority/page.mdx
+++ b/docs/app/priority/page.mdx
@@ -10,7 +10,7 @@ With the Priority module, Boros allows users to configure queues to prioritise t
 Follow the [configuration](../configuration) to configure the priority queues.
 
 ### Example
-The quota is 10, so the fanout stage has a backpressure of 10, meaning only 10 transactions can be waiting for propagation. The quota is released when transactions are sent, allowing new transactions to wait. Furthermore, two queues are configured: Queue A with a weight of 3 and Queue B with a weight of 2. Queue A has higher priority than Queue B, so Queue A receives 6 slots and Queue B receives 4 slots from the quota.
+Two queues are configured: Queue A with a weight of 3 and Queue B with a weight of 2. Since Queue A has a higher weight, it receives more slots than Queue B. Specifically, the total available slots are distributed proportionally based on weight, giving Queue A 60% of the slots and Queue B 40%. This ensures that Queue A has higher priority when distributing transactions.
 
 ### Default
 Priority configurations are not required. If not configured, the default queue is used. The default queue has a weight of 1 but can be replaced by setting a configuration with the name default. Transactions with unknown queues are processed using the default weight.

--- a/src/pipeline/fanout/mod.rs
+++ b/src/pipeline/fanout/mod.rs
@@ -15,6 +15,8 @@ use crate::{
     storage::{sqlite::SqliteTransaction, Transaction, TransactionStatus},
 };
 
+use super::CAP;
+
 pub mod mempool;
 pub mod peer;
 pub mod peer_manager;
@@ -98,9 +100,10 @@ impl gasket::framework::Worker<Stage> for Worker {
         let additional_peers_required =
             desired_count as usize - self.peer_manager.connected_peers_count().await;
 
+        // TODO: calculate the current cap, (CAP - busy slots) = available cap
         let transactions = stage
             .priority
-            .next(TransactionStatus::Validated)
+            .next(TransactionStatus::Validated, CAP)
             .await
             .or_retry()?;
 

--- a/src/pipeline/ingest.rs
+++ b/src/pipeline/ingest.rs
@@ -9,6 +9,8 @@ use crate::{
     storage::{sqlite::SqliteTransaction, Transaction, TransactionStatus},
 };
 
+use super::CAP;
+
 #[derive(Stage)]
 #[stage(name = "ingest", unit = "Vec<Transaction>", worker = "Worker")]
 pub struct Stage {
@@ -36,7 +38,7 @@ impl gasket::framework::Worker<Stage> for Worker {
     ) -> Result<WorkSchedule<Vec<Transaction>>, WorkerError> {
         let transactions = stage
             .priority
-            .next(TransactionStatus::Pending)
+            .next(TransactionStatus::Pending, CAP)
             .await
             .or_retry()?;
 

--- a/src/pipeline/mod.rs
+++ b/src/pipeline/mod.rs
@@ -19,6 +19,8 @@ pub mod fanout;
 pub mod ingest;
 pub mod monitor;
 
+const CAP: u16 = 50;
+
 pub async fn run(
     config: Config,
     tx_storage: Arc<SqliteTransaction>,


### PR DESCRIPTION
After discussing about sorting algorithm, we decided to change the name DEFAULT_QUOTA to CAP, where CAP is the capacity that the broadcast queue in the fanout stage has to process transactions. When the scheduling process to get transactions is executed, the available capacity on the queue is calculated and the priority returns based on the capacity available.