### PR TITLE
feat: ingest stage tx scheduling backpressure

### DIFF
--- a/src/network/peer_manager.rs
+++ b/src/network/peer_manager.rs
@@ -76,11 +76,11 @@ impl PeerManager {
             *peer = Some(new_peer);
         }
 
-        self.start_recv_drain().await;
+        self.start_recv_task().await;
         Ok(())
     }
 
-    async fn start_recv_drain(&self) {
+    async fn start_recv_task(&self) {
         let receiver = Arc::clone(&self.receiver);
         let timeout_duration = Duration::from_millis(500);
 

--- a/src/pipeline/ingest.rs
+++ b/src/pipeline/ingest.rs
@@ -50,7 +50,7 @@ impl gasket::framework::Worker<Stage> for Worker {
         &mut self,
         stage: &mut Stage,
     ) -> Result<WorkSchedule<Vec<Transaction>>, WorkerError> {
-        let queued_len = stage.output.len();
+        let queued_len = stage.output.len().unwrap_or(0);
         let current_cap = CAP - queued_len as u16;
 
         if current_cap == 0 {

--- a/src/pipeline/ingest.rs
+++ b/src/pipeline/ingest.rs
@@ -142,9 +142,16 @@ impl gasket::framework::Worker<Stage> for Worker {
         &mut self,
         stage: &mut Stage,
     ) -> Result<WorkSchedule<Vec<Transaction>>, WorkerError> {
+        let queued_len = stage.output.queued_len().unwrap_or(0);
+        let current_cap = CAP - queued_len as u16;
+
+        if current_cap == 0 {
+            return Ok(WorkSchedule::Idle);
+        }
+
         let transactions = stage
             .priority
-            .next(TransactionStatus::Pending, CAP)
+            .next(TransactionStatus::Pending, current_cap)
             .await
             .or_retry()?;
 

--- a/src/pipeline/ingest.rs
+++ b/src/pipeline/ingest.rs
@@ -142,7 +142,7 @@ impl gasket::framework::Worker<Stage> for Worker {
         &mut self,
         stage: &mut Stage,
     ) -> Result<WorkSchedule<Vec<Transaction>>, WorkerError> {
-        let queued_len = stage.output.queued_len().unwrap_or(0);
+        let queued_len = stage.output.len();
         let current_cap = CAP - queued_len as u16;
 
         if current_cap == 0 {

--- a/src/pipeline/mod.rs
+++ b/src/pipeline/mod.rs
@@ -1,7 +1,6 @@
 use std::sync::Arc;
 
 use anyhow::Result;
-use gasket::messaging::tokio::ChannelSendAdapter;
 
 use crate::{
     ledger::{
@@ -32,15 +31,10 @@ pub async fn run(
     let relay_adapter: Arc<dyn RelayDataAdapter + Send + Sync> =
         Arc::new(MockRelayDataAdapter::new());
 
-    let (sender, _) = gasket::messaging::tokio::broadcast_channel::<Vec<u8>>(CAP as usize);
-
-    let broadcast_sender = match &sender {
-        ChannelSendAdapter::Broadcast(sender) => sender.clone(),
-        _ => panic!("Expected broadcast sender"),
-    };
+    let (sender, receiver) = gasket::messaging::tokio::broadcast_channel::<Vec<u8>>(CAP as usize);
 
     let peer_addrs = config.peer_manager.peers.clone();
-    let peer_manager = PeerManager::new(2, peer_addrs, broadcast_sender);
+    let peer_manager = PeerManager::new(2, peer_addrs, receiver);
 
     peer_manager.init().await?;
 


### PR DESCRIPTION
- Ingest stage now has a calculation for `current_cap` using gasket's exposed len() function
  - Allows us to control tx scheduling in the ingest stage if broadcast channel is at max capacity